### PR TITLE
Implement Error Handling Module

### DIFF
--- a/contracts/hello-world/src/error.rs
+++ b/contracts/hello-world/src/error.rs
@@ -1,0 +1,48 @@
+use soroban_sdk::{Env, contracttype};
+
+#[contracttype]
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub enum Error {
+    // Asset exist
+    AssetAlreadyExists,
+    //Asset not found
+    AssetNotFound,
+    // Branch already exists
+    BranchAlreadyExists,
+    // Branch not found
+    BranchNotFound,
+    // Subscription already exist
+    SubscriptionAlreadyExists,
+    // User not authorized
+    Unauthorized,
+    // Payment is not valid
+    InvalidPayment
+}
+
+pub fn dummy_function(_env: Env, asset_exists: bool) -> Result<(), Error> {
+    if asset_exists {
+        Err(Error::AssetAlreadyExists)
+    } else {
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use soroban_sdk::{Env};
+
+    #[test]
+    fn test_dummy_function_asset_exists() {
+        let env = Env::default();
+        let result = dummy_function(env.clone(), true);
+        assert_eq!(result, Err(Error::AssetAlreadyExists));
+    }
+
+    #[test]
+    fn test_dummy_function_asset_not_exists() {
+        let env = Env::default();
+        let result = dummy_function(env.clone(), false);
+        assert_eq!(result, Ok(()));
+    }
+}

--- a/contracts/hello-world/src/lib.rs
+++ b/contracts/hello-world/src/lib.rs
@@ -1,5 +1,8 @@
 #![no_std]
+pub mod error;
+
 use soroban_sdk::{contract, contractimpl, vec, Env, String, Vec};
+use crate::error::Error;
 
 #[contract]
 pub struct Contract;
@@ -19,5 +22,6 @@ impl Contract {
         vec![&env, String::from_str(&env, "Hello"), to]
     }
 }
+
 
 mod test;


### PR DESCRIPTION
closes #245 

is there any reason why you choose to use `#[contracttype]` instead of `#[contracttype]` for the Error enum?