### PR TITLE
feat: implement basic breadcrumb navigation component

### DIFF
--- a/frontend/components/ui/Breadcrumb.example.tsx
+++ b/frontend/components/ui/Breadcrumb.example.tsx
@@ -1,0 +1,40 @@
+import Breadcrumb from './Breadcrumb';
+
+// Example usage in a Dashboard page
+export const DashboardBreadcrumb = () => {
+    return (
+        <Breadcrumb
+            items={[
+                { label: 'Home', href: '/' },
+                { label: 'Dashboard' }
+            ]}
+        />
+    );
+};
+
+// Example usage in a Profile page
+export const ProfileBreadcrumb = () => {
+    return (
+        <Breadcrumb
+            items={[
+                { label: 'Home', href: '/' },
+                { label: 'Settings', href: '/settings' },
+                { label: 'Profile' }
+            ]}
+        />
+    );
+};
+
+// Example usage with nested navigation
+export const AssetDetailBreadcrumb = () => {
+    return (
+        <Breadcrumb
+            items={[
+                { label: 'Home', href: '/' },
+                { label: 'Assets', href: '/assets' },
+                { label: 'Equipment', href: '/assets/equipment' },
+                { label: 'Laptop #12345' }
+            ]}
+        />
+    );
+};

--- a/frontend/components/ui/Breadcrumb.tsx
+++ b/frontend/components/ui/Breadcrumb.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import Link from 'next/link';
+
+interface BreadcrumbItem {
+    label: string;
+    href?: string;
+}
+
+interface BreadcrumbProps {
+    items: BreadcrumbItem[];
+}
+
+const Breadcrumb: React.FC<BreadcrumbProps> = ({ items }) => {
+    return (
+        <nav aria-label="Breadcrumb" className="flex gap-2 text-sm">
+            {items.map((item, index) => {
+                const isLast = index === items.length - 1;
+
+                return (
+                    <React.Fragment key={index}>
+                        {isLast ? (
+                            <span className="text-gray-600 font-medium" aria-current="page">
+                                {item.label}
+                            </span>
+                        ) : (
+                            <React.Fragment>
+                                <Link
+                                    href={item.href || '#'}
+                                    className="text-blue-600 hover:text-blue-800 hover:underline transition-colors"
+                                >
+                                    {item.label}
+                                </Link>
+                                <span className="text-gray-400" aria-hidden="true">
+                                    /
+                                </span>
+                            </React.Fragment>
+                        )}
+                    </React.Fragment>
+                );
+            })}
+        </nav>
+    );
+};
+
+export default Breadcrumb;

--- a/frontend/components/ui/index.ts
+++ b/frontend/components/ui/index.ts
@@ -1,0 +1,1 @@
+export { default as Breadcrumb } from './Breadcrumb';


### PR DESCRIPTION
## Description
Implements a basic breadcrumb navigation component as requested in #316.

## Changes Made
- ✅ Created `Breadcrumb.tsx` component in `components/ui/`
- ✅ Accepts array of `{ label: string, href?: string }` items as props
- ✅ Renders links for all items except the last (plain text)
- ✅ Uses Tailwind classes: `flex`, `gap-2`, `text-sm`
- ✅ Fully reusable across multiple pages
- ✅ Added example usage demonstrations


Closes #316