### PR TITLE
Fix: FRONTEND: Date Formatter (Utility Function)

### DIFF
--- a/frontend/lib/utils/formatDate.test.ts
+++ b/frontend/lib/utils/formatDate.test.ts
@@ -1,0 +1,122 @@
+import { formatDate } from "./formatDate";
+
+describe("formatDate", () => {
+  describe("short format", () => {
+    it("should format date as DD/MM/YYYY", () => {
+      expect(formatDate("2025-10-01", "short")).toBe("01/10/2025");
+      expect(formatDate(new Date("2025-12-25"), "short")).toBe("25/12/2025");
+      expect(formatDate(new Date("2024-01-01"), "short")).toBe("01/01/2024");
+    });
+
+    it("should handle different date inputs", () => {
+      expect(formatDate(1735689600000, "short")).toBe("01/01/2025"); // timestamp
+      expect(formatDate("2025-06-15T10:30:00Z", "short")).toBe("15/06/2025");
+    });
+
+    it("should handle edge cases", () => {
+      expect(formatDate("2025-02-29", "short")).toBe("01/03/2025"); // leap year edge case
+      expect(formatDate("2024-02-29", "short")).toBe("29/02/2024"); // valid leap year
+    });
+  });
+
+  describe("relative format", () => {
+    beforeEach(() => {
+      // Mock Date.now() to a fixed time for consistent testing
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2025-01-15T12:00:00Z"));
+    });
+
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it("should format relative dates correctly", () => {
+      // 1 day ago
+      const oneDayAgo = new Date("2025-01-14T12:00:00Z");
+      expect(formatDate(oneDayAgo, "relative")).toBe("1 day ago");
+
+      // 2 days ago
+      const twoDaysAgo = new Date("2025-01-13T12:00:00Z");
+      expect(formatDate(twoDaysAgo, "relative")).toBe("2 days ago");
+
+      // 1 hour ago
+      const oneHourAgo = new Date("2025-01-15T11:00:00Z");
+      expect(formatDate(oneHourAgo, "relative")).toBe("1 hour ago");
+
+      // 30 minutes ago
+      const thirtyMinutesAgo = new Date("2025-01-15T11:30:00Z");
+      expect(formatDate(thirtyMinutesAgo, "relative")).toBe("30 minutes ago");
+
+      // 1 minute ago
+      const oneMinuteAgo = new Date("2025-01-15T11:59:00Z");
+      expect(formatDate(oneMinuteAgo, "relative")).toBe("1 minute ago");
+    });
+
+    it("should format future dates correctly", () => {
+      // 1 day from now
+      const oneDayFromNow = new Date("2025-01-16T12:00:00Z");
+      expect(formatDate(oneDayFromNow, "relative")).toBe("in 1 day");
+
+      // 2 days from now
+      const twoDaysFromNow = new Date("2025-01-17T12:00:00Z");
+      expect(formatDate(twoDaysFromNow, "relative")).toBe("in 2 days");
+
+      // 1 hour from now
+      const oneHourFromNow = new Date("2025-01-15T13:00:00Z");
+      expect(formatDate(oneHourFromNow, "relative")).toBe("in 1 hour");
+    });
+
+    it("should handle same time as 'now'", () => {
+      const now = new Date("2025-01-15T12:00:00Z");
+      expect(formatDate(now, "relative")).toBe("now");
+    });
+
+    it("should handle very recent times", () => {
+      // 30 seconds ago
+      const thirtySecondsAgo = new Date("2025-01-15T11:59:30Z");
+      expect(formatDate(thirtySecondsAgo, "relative")).toBe("30 seconds ago");
+
+      // 1 second ago
+      const oneSecondAgo = new Date("2025-01-15T11:59:59Z");
+      expect(formatDate(oneSecondAgo, "relative")).toBe("1 second ago");
+    });
+
+    it("should handle longer periods", () => {
+      // 1 month ago
+      const oneMonthAgo = new Date("2024-12-15T12:00:00Z");
+      expect(formatDate(oneMonthAgo, "relative")).toBe("1 month ago");
+
+      // 1 year ago
+      const oneYearAgo = new Date("2024-01-15T12:00:00Z");
+      expect(formatDate(oneYearAgo, "relative")).toBe("1 year ago");
+    });
+  });
+
+  describe("error handling", () => {
+    it("should throw error for invalid date", () => {
+      expect(() => formatDate("invalid-date", "short")).toThrow("Invalid date provided");
+      expect(() => formatDate("not-a-date", "relative")).toThrow("Invalid date provided");
+      expect(() => formatDate(NaN, "short")).toThrow("Invalid date provided");
+    });
+
+    it("should throw error for unsupported format", () => {
+      expect(() => formatDate("2025-01-01", "invalid" as any)).toThrow("Unsupported format: invalid");
+    });
+  });
+
+  describe("acceptance criteria", () => {
+    it("should meet the specific acceptance criteria", () => {
+      // formatDate("2025-10-01", "short") → "01/10/2025"
+      expect(formatDate("2025-10-01", "short")).toBe("01/10/2025");
+
+      // formatDate(Date.now() - 86400000, "relative") → "1 day ago"
+      jest.useFakeTimers();
+      jest.setSystemTime(new Date("2025-01-15T12:00:00Z"));
+      
+      const oneDayAgo = Date.now() - 86400000; // 86400000 ms = 1 day
+      expect(formatDate(oneDayAgo, "relative")).toBe("1 day ago");
+      
+      jest.useRealTimers();
+    });
+  });
+});

--- a/frontend/lib/utils/formatDate.ts
+++ b/frontend/lib/utils/formatDate.ts
@@ -1,0 +1,77 @@
+
+export type DateFormat = 'short' | 'relative';
+
+/**
+ * Formats a date into a readable string
+ * @param date - Date object, string, or timestamp
+ * @param format - Format type: 'short' for DD/MM/YYYY, 'relative' for relative time
+ * @returns Formatted date string
+ */
+export function formatDate(date: Date | string | number, format: DateFormat): string {
+  const dateObj = new Date(date);
+  
+  if (isNaN(dateObj.getTime())) {
+    throw new Error('Invalid date provided');
+  }
+
+  switch (format) {
+    case 'short':
+      return formatShortDate(dateObj);
+    case 'relative':
+      return formatRelativeDate(dateObj);
+    default:
+      throw new Error(`Unsupported format: ${format}`);
+  }
+}
+
+/**
+ * Formats date as DD/MM/YYYY using Intl.DateTimeFormat
+ */
+function formatShortDate(date: Date): string {
+  const formatter = new Intl.DateTimeFormat('en-GB', {
+    day: '2-digit',
+    month: '2-digit',
+    year: 'numeric'
+  });
+  
+  return formatter.format(date);
+}
+
+/**
+ * Formats date as relative time using Intl.RelativeTimeFormat
+ */
+function formatRelativeDate(date: Date): string {
+  const now = new Date();
+  const diffInMs = date.getTime() - now.getTime();
+  const diffInSeconds = Math.round(diffInMs / 1000);
+  
+  // Handle same time
+  if (Math.abs(diffInSeconds) < 1) {
+    return 'now';
+  }
+  
+  const formatter = new Intl.RelativeTimeFormat('en', {
+    numeric: 'always' // Use "1 day ago" instead of "yesterday" for consistency
+  });
+  
+  // Determine the appropriate unit and value
+  const units: Array<{ unit: Intl.RelativeTimeFormatUnit; value: number }> = [
+    { unit: 'year', value: 365 * 24 * 60 * 60 },
+    { unit: 'month', value: 30 * 24 * 60 * 60 },
+    { unit: 'day', value: 24 * 60 * 60 },
+    { unit: 'hour', value: 60 * 60 },
+    { unit: 'minute', value: 60 },
+    { unit: 'second', value: 1 }
+  ];
+  
+  for (const { unit, value } of units) {
+    const absDiff = Math.abs(diffInSeconds);
+    if (absDiff >= value) {
+      const relativeValue = Math.round(diffInSeconds / value);
+      return formatter.format(relativeValue, unit);
+    }
+  }
+  
+  // Fallback for very small differences
+  return formatter.format(diffInSeconds, 'second');
+}


### PR DESCRIPTION
##  Description
Implements a comprehensive date formatting utility function as requested in issue #308. The utility supports multiple date formats including short date (DD/MM/YYYY) and relative time formatting.

##  Features Implemented
- **Short Format**: Uses `Intl.DateTimeFormat` to format dates as DD/MM/YYYY
- **Relative Format**: Uses `Intl.RelativeTimeFormat` to show relative time (e.g., "1 day ago", "in 2 hours")
- **TypeScript Support**: Full type definitions with `DateFormat` type
- **Error Handling**: Proper validation for invalid dates and unsupported formats
- **Comprehensive Testing**: 11 unit tests covering all scenarios

## 🧪 Test Results
All tests are passing successfully:

<img width="1028" height="692" alt="date-test-passed" src="https://github.com/user-attachments/assets/3d046616-205a-499a-b904-8ad342695662" />

**Test Summary:**
- ✅ **11 tests passed, 0 failed**
- ✅ **Short format tests**: 3/3 passed
- ✅ **Relative format tests**: 5/5 passed  
- ✅ **Error handling tests**: 2/2 passed
- ✅ **Acceptance criteria tests**: 1/1 passed

## ✅ Acceptance Criteria Met
- `formatDate("2025-10-01", "short") → "01/10/2025"` ✅
- `formatDate(Date.now() - 86400000, "relative") → "1 day ago"` ✅

## 📁 Files Added
- `frontend/lib/utils/formatDate.ts` - Main utility function
- `frontend/lib/utils/formatDate.test.ts` - Comprehensive test suite

## 🔧 Technical Details
- Uses modern `Intl.DateTimeFormat` and `Intl.RelativeTimeFormat` APIs
- Supports multiple input types: Date objects, strings, and timestamps
- Follows existing project patterns and coding standards
- Includes JSDoc documentation for better maintainability

## 🎯 Usage Examples
```typescript
import { formatDate } from './lib/utils/formatDate';

// Short format
formatDate("2025-10-01", "short"); // "01/10/2025"
formatDate(new Date(), "short"); // "15/01/2025"

// Relative format  
formatDate(Date.now() - 86400000, "relative"); // "1 day ago"
formatDate(Date.now() + 3600000, "relative"); // "in 1 hour"
```

Closes #308