### PR TITLE
feat: Create a Reusable Button Component

### DIFF
--- a/frontend/components/ui/Button.tsx
+++ b/frontend/components/ui/Button.tsx
@@ -1,0 +1,44 @@
+'use client'
+import React from 'react';
+
+interface ButtonProps extends React.ButtonHTMLAttributes<HTMLButtonElement> {
+  variant?: 'primary' | 'secondary';
+  size?: 'sm' | 'md' | 'lg';
+  children: React.ReactNode;
+}
+
+const Button: React.FC<ButtonProps> = ({
+  variant = 'primary',
+  size = 'md',
+  disabled = false,
+  children,
+  className = '',
+  ...props
+}) => {
+  const baseStyles = 'font-medium rounded-lg transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed';
+
+  const variantStyles = {
+    primary: 'bg-blue-600 text-white hover:bg-blue-700 focus:ring-blue-500 disabled:hover:bg-blue-600',
+    secondary: 'bg-gray-200 text-gray-900 hover:bg-gray-300 focus:ring-gray-500 disabled:hover:bg-gray-200',
+  };
+
+  const sizeStyles = {
+    sm: 'px-3 py-1.5 text-sm',
+    md: 'px-4 py-2 text-base',
+    lg: 'px-6 py-3 text-lg',
+  };
+
+  const classes = `${baseStyles} ${variantStyles[variant]} ${sizeStyles[size]} ${className}`.trim();
+
+  return (
+    <button
+      className={classes}
+      disabled={disabled}
+      {...props}
+    >
+      {children}
+    </button>
+  );
+};
+
+export default Button;


### PR DESCRIPTION
Summary

Implements a fully-typed, reusable Button component in components/ui/Button.tsx to ensure consistent button styling across the application.

Changes

✅ Created components/ui/Button.tsx with TypeScript support
✅ Added variant prop: primary (blue) and secondary (gray)
✅ Added size prop: sm, md, lg
✅ Includes proper disabled state styling
✅ Extends native HTML button attributes for full flexibility
✅ Implements accessible focus states and smooth hover transitions
✅ Marked as Client Component with 'use client' directive for Next.js App Router compatibility