### PR TITLE
FRONTEND: Implement Not Found Page #318

### DIFF
--- a/frontend/app/not-found.tsx
+++ b/frontend/app/not-found.tsx
@@ -1,0 +1,23 @@
+import Link from 'next/link';
+
+export default function NotFound() {
+  return (
+    <div className="flex flex-col items-center justify-center min-h-screen px-4">
+      <div className="text-center">
+        <h1 className="text-6xl font-bold text-gray-800 mb-4">404</h1>
+        <h2 className="text-2xl font-semibold text-gray-700 mb-4">
+          Page not found
+        </h2>
+        <p className="text-lg text-gray-600 mb-8">
+          Sorry, we couldn't find the page you're looking for.
+        </p>
+        <Link 
+          href="/" 
+          className="inline-flex items-center px-6 py-3 border border-transparent text-base font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 transition-colors duration-200"
+        >
+          Go back home
+        </Link>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Summary
This PR introduces a global 404 Not Found page for the application.

### Changes
- Added `app/not-found.tsx` to handle invalid routes.
- The page displays a friendly "Page not found" message.
- Includes a link back to the homepage using `next/link`.
- Styled with basic Tailwind utilities (`flex`, `justify-center`, `text-lg`, etc.).
- Requires no extra design assets.

### Testing
- Navigate to any non-existing route (e.g., `/random-page`).
- Confirm that the Not Found page is displayed with the correct message and a working link back to `/`.

### Screenshot
<img width="1339" height="554" alt="Screenshot 2025-10-03 145918" src="https://github.com/user-attachments/assets/7cd14474-c962-47a2-a805-56e28afc2197" />


### Issue Reference
Closes #318
