### PR TITLE
chore: #306 add parseQueryParams utility function

### DIFF
--- a/frontend/lib/utils/parseQueryParams.test.ts
+++ b/frontend/lib/utils/parseQueryParams.test.ts
@@ -1,0 +1,34 @@
+import { parseQueryParams } from './parseQueryParams';
+
+describe('parseQueryParams', () => {
+
+  it('should parse a standard query string', () => {
+    const query = '?page=2&limit=10';
+    const result = parseQueryParams(query);
+    expect(result).toEqual({ page: '2', limit: '10' });
+  });
+
+  it('should work with empty query string', () => {
+    const query = '';
+    const result = parseQueryParams(query);
+    expect(result).toEqual({});
+  });
+
+  it('should work with URLSearchParams', () => {
+    const searchParams = new URLSearchParams({ page: '5', sort: 'desc' });
+    const result = parseQueryParams(searchParams);
+    expect(result).toEqual({ page: '5', sort: 'desc' });
+  });
+
+  it('should handle query strings without "?"', () => {
+    const query = 'foo=bar&baz=qux';
+    const result = parseQueryParams(query);
+    expect(result).toEqual({ foo: 'bar', baz: 'qux' });
+  });
+
+  it('should handle repeated keys by keeping the last value', () => {
+    const query = '?key=1&key=2';
+    const result = parseQueryParams(query);
+    expect(result).toEqual({ key: '2' });
+  });
+});

--- a/frontend/lib/utils/parseQueryParams.ts
+++ b/frontend/lib/utils/parseQueryParams.ts
@@ -1,0 +1,10 @@
+export function parseQueryParams(query: string | URLSearchParams): Record<string, string> {
+  const params = new URLSearchParams(query instanceof URLSearchParams ? query.toString() : query);
+  const result: Record<string, string> = {};
+
+  params.forEach((value, key) => {
+    result[key] = value;
+  });
+
+  return result;
+};


### PR DESCRIPTION
# Changes made
- Created parseQueryParams file to implement  Parse Query Params (Utility Function);
- Created parseQueryParams.test.ts file to run unit test cases as follows: 
- Check for Standard query string input
- Check for Empty query string input
- Check for URLSearchParams object input
- Check for Query string without leading ?
- Check for Repeated key is passed